### PR TITLE
fix can't get current branch

### DIFF
--- a/deploy/image.sh
+++ b/deploy/image.sh
@@ -7,7 +7,7 @@ set -o pipefail
 work_dir=$(pwd)
 cd $(dirname $0)
 
-branch=$(git symbolic-ref --short HEAD)
+branch=$(git rev-parse --abbrev-ref HEAD)
 commit_id=$(git describe --tags --always --dirty)
 image_tag="${branch}-${commit_id}"
 repository=$(pwd | xargs dirname | xargs basename)


### PR DESCRIPTION
You have also git symbolic-ref HEAD which displays the full refspec.

To show only the branch name in Git v1.8 and later (thank's to Greg for pointing that out):

git symbolic-ref --short HEAD
On Git v1.7+ you can also do:

git rev-parse --abbrev-ref HEAD
